### PR TITLE
Feature/toggle labels

### DIFF
--- a/frontend/naturewatch/src/components/MapComponent.vue
+++ b/frontend/naturewatch/src/components/MapComponent.vue
@@ -202,11 +202,23 @@ function addSourceToMap(
 /** Add layer to the map */
 function addLayerToMap(layer: MapLayer, map: mapboxgl.Map | null) {
   if (map) {
-    map.addLayer({
-      id: layer.title + activeYear.value,
-      type: 'raster',
-      source: layer.title + activeYear.value,
-    });
+    // Add layer below labels and lines
+    let firstSymbolId;
+
+    for (const layer of map.getStyle().layers) {
+      if (layer.type === 'symbol' || layer.type === 'line') {
+        firstSymbolId = layer.id;
+        break;
+      }
+    }
+    map.addLayer(
+      {
+        id: layer.title + activeYear.value,
+        type: 'raster',
+        source: layer.title + activeYear.value,
+      },
+      firstSymbolId
+    );
   }
 }
 

--- a/frontend/naturewatch/src/components/MapComponent.vue
+++ b/frontend/naturewatch/src/components/MapComponent.vue
@@ -45,6 +45,9 @@ const activeYear = computed(() => timelineStore.activeYear);
 const drawerVisible = computed(() => drawerStore.visible);
 const drawerWidth = computed(() => drawerStore.width);
 
+// Label visibility
+const areLabelsVisible = ref(false);
+
 const mapOptions: MapboxMap = {
   accessToken:
     'pk.eyJ1IjoibmF0dXJlLXdhdGNoIiwiYSI6ImNsZWU4MHN6MjBlZmwzcG12cTdnNGJwcGEifQ.gK_j2FlTCHa0bV0cUT_3IA',
@@ -103,6 +106,26 @@ onMounted(() => {
 });
 
 /** Methods */
+/** Toggle labels on basemap */
+function toggleLabels(map: mapboxgl.Map | null) {
+  if (map) {
+    let anyLabelIsVisible = false;
+    map.getStyle().layers.forEach(function (layer) {
+      if (layer.type === 'symbol' || layer.type === 'line') {
+        const visibility = map.getLayoutProperty(layer.id, 'visibility');
+        if (visibility === 'visible') {
+          map.setLayoutProperty(layer.id, 'visibility', 'none');
+        } else {
+          map.setLayoutProperty(layer.id, 'visibility', 'visible');
+          anyLabelIsVisible = true;
+        }
+      }
+    });
+    areLabelsVisible.value = anyLabelIsVisible;
+    console.log(`#MapComponent: ${areLabelsVisible.value}`);
+  }
+}
+
 /** Handle basemap change */
 function handleBasemapChanged(newStyleUrl: string) {
   if (map.value) {
@@ -217,6 +240,14 @@ function addSourceAndLayer(
           icon="mdi-theme-light-dark"
           @click="configStore.toggleTheme"
         />
+        <!-- Toggle basemap labels -->
+        <v-btn
+          id="labelsButton"
+          class="labels-button"
+          :class="{ 'labels-visible': areLabelsVisible }"
+          icon="mdi-format-title"
+          @click="toggleLabels(map)"
+        />
         <!-- Toggle Basemap type -->
         <BasemapButtonComponent
           id="basmapButton"
@@ -264,7 +295,15 @@ function addSourceAndLayer(
   right: 40px;
   z-index: 10;
 }
-
+.labels-button {
+  position: absolute;
+  bottom: 120px;
+  right: 40px;
+  z-index: 10;
+}
+.labels-button.labels-visible {
+  background-color: green;
+}
 .timeline {
   position: absolute;
   top: 50px;

--- a/frontend/naturewatch/src/components/MapComponent.vue
+++ b/frontend/naturewatch/src/components/MapComponent.vue
@@ -247,11 +247,14 @@ function addSourceAndLayer(
         <!-- Toggle basemap labels -->
         <v-btn
           id="labelsButton"
+          size="small"
+          variant="tonal"
           class="labels-button"
           :class="{ 'labels-visible': areLabelsVisible }"
-          icon="mdi-format-title"
           @click="handleLabelsChanged(map)"
-        />
+        >
+          Labels
+        </v-btn>
         <!-- Toggle Basemap type -->
         <BasemapButtonComponent
           id="basmapButton"
@@ -306,7 +309,7 @@ function addSourceAndLayer(
   z-index: 10;
 }
 .labels-button.labels-visible {
-  background-color: green;
+  background-color: rgb(115, 185, 85);
 }
 .timeline {
   position: absolute;

--- a/frontend/naturewatch/src/store/BasemapStore.ts
+++ b/frontend/naturewatch/src/store/BasemapStore.ts
@@ -7,31 +7,41 @@ const useBasemapStore = defineStore('basemap', () => {
   // State
   const title: Ref<string> = ref('Satellite');
   const url: Ref<string> = ref(
-    'mapbox://styles/nature-watch/clhasye2x014301pg03i97sca'
+    'mapbox://styles/nature-watch/clhasd44b012301pg7dilg74p'
   );
+  const labelsVisible: Ref<boolean> = ref(true);
 
   // Getters
-  /**
-   *
-   */
+  /** Get current active basemap style */
   function currentBasemap(): Basemap {
     return { title: title.value, url: url.value };
   }
 
   // Actions
-  /**
-   *
-   */
+  /** Toggle basemap style between Satellite and Streets*/
   function toggleBasemap() {
     if (title.value === 'Satellite') {
       title.value = 'Streets';
       url.value = 'mapbox://styles/mapbox/streets-v12';
     } else {
       title.value = 'Satellite';
-      url.value = 'mapbox://styles/nature-watch/clhasye2x014301pg03i97sca';
+      url.value = 'mapbox://styles/nature-watch/clhasd44b012301pg7dilg74p';
     }
   }
-  return { title, url, currentBasemap, toggleBasemap };
+
+  /** Toggle labels of basemap style */
+  function toggleLabelsTo(visible: boolean) {
+    labelsVisible.value = visible;
+  }
+
+  return {
+    title,
+    url,
+    labelsVisible,
+    currentBasemap,
+    toggleBasemap,
+    toggleLabelsTo,
+  };
 });
 
 export default useBasemapStore;

--- a/frontend/naturewatch/src/store/BasemapStore.ts
+++ b/frontend/naturewatch/src/store/BasemapStore.ts
@@ -31,7 +31,6 @@ const useBasemapStore = defineStore('basemap', () => {
       url.value = 'mapbox://styles/nature-watch/clhasye2x014301pg03i97sca';
     }
   }
-
   return { title, url, currentBasemap, toggleBasemap };
 });
 


### PR DESCRIPTION
## Description

1. I added a labelButton above the baseMapButton that toggles the labels (symbol and line layers). This now works seamlessly even when switching between basemap styles. The initial state of the label visibility is set in the baseMapStore and then a function manages when to show labels on the style (whenever the baseMapButton or labelsButton is pressed)

2. I also added functionality for any mapLayers (such as tree loss or fires) are added below all the label layers of the style.

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions/changes to the documentation


## User Experience:

![labels](https://github.com/marynvdl/naturewatch-app/assets/46701604/67f69566-617f-4820-ab36-ea205080d977)
