### PR TITLE
Feature/vector tiles example

### DIFF
--- a/frontend/naturewatch/src/components/MapComponent.vue
+++ b/frontend/naturewatch/src/components/MapComponent.vue
@@ -197,7 +197,7 @@ function addSourceToMap(
           tileSize: 256,
         });
       }
-    } else if (layer.type === 'vector') {
+    } else if (layer.type === 'circle' || layer.type === 'line') {
       if (!map?.getSource(layer.title + activeYear.value)) {
         map.addSource(layer.title + activeYear.value, {
           type: 'vector',
@@ -230,17 +230,14 @@ function addLayerToMap(layer: MapLayer, map: mapboxgl.Map | null) {
         },
         firstSymbolId
       );
-    } else if (layer.type === 'vector') {
+    } else if (layer.type === 'circle' || layer.type === 'line') {
       map.addLayer(
         {
           id: layer.title + activeYear.value,
-          type: 'circle',
+          type: layer.type,
           source: layer.title + activeYear.value,
-          'source-layer': 'dams',
-          paint: {
-            'circle-color': '#61d2ec',
-            'circle-radius': 3,
-          },
+          'source-layer': layer.sourceLayer,
+          paint: layer.paint as any,
         },
         firstSymbolId
       );

--- a/frontend/naturewatch/src/components/MapComponent.vue
+++ b/frontend/naturewatch/src/components/MapComponent.vue
@@ -189,12 +189,21 @@ function addSourceToMap(
   map: mapboxgl.Map | null
 ) {
   if (map) {
-    if (!map?.getSource(layer.title + activeYear.value)) {
-      map.addSource(layer.title + activeYear.value, {
-        type: 'raster',
-        tiles: [layerUrl],
-        tileSize: 256,
-      });
+    if (layer.type === 'raster') {
+      if (!map?.getSource(layer.title + activeYear.value)) {
+        map.addSource(layer.title + activeYear.value, {
+          type: 'raster',
+          tiles: [layerUrl],
+          tileSize: 256,
+        });
+      }
+    } else if (layer.type === 'vector') {
+      if (!map?.getSource(layer.title + activeYear.value)) {
+        map.addSource(layer.title + activeYear.value, {
+          type: 'vector',
+          url: layerUrl,
+        });
+      }
     }
   }
 }
@@ -211,14 +220,31 @@ function addLayerToMap(layer: MapLayer, map: mapboxgl.Map | null) {
         break;
       }
     }
-    map.addLayer(
-      {
-        id: layer.title + activeYear.value,
-        type: 'raster',
-        source: layer.title + activeYear.value,
-      },
-      firstSymbolId
-    );
+
+    if (layer.type === 'raster') {
+      map.addLayer(
+        {
+          id: layer.title + activeYear.value,
+          type: 'raster',
+          source: layer.title + activeYear.value,
+        },
+        firstSymbolId
+      );
+    } else if (layer.type === 'vector') {
+      map.addLayer(
+        {
+          id: layer.title + activeYear.value,
+          type: 'circle',
+          source: layer.title + activeYear.value,
+          'source-layer': 'dams',
+          paint: {
+            'circle-color': '#61d2ec',
+            'circle-radius': 3,
+          },
+        },
+        firstSymbolId
+      );
+    }
   }
 }
 

--- a/frontend/naturewatch/src/interfaces/MapLayerInterface.ts
+++ b/frontend/naturewatch/src/interfaces/MapLayerInterface.ts
@@ -1,5 +1,4 @@
 import type { MapLayerType, MapLayerButtonType } from '../types/MapLayerType';
-import type MapLayerPaint from '../interfaces/MapLayerPaintInterface';
 
 /** Map Layer Interface */
 export default interface MapLayer {
@@ -13,8 +12,12 @@ export default interface MapLayer {
   type: MapLayerType;
   /** Source layer from Mapbox */
   sourceLayer?: string;
-  /** Layer source url */
-  paint?: MapLayerPaint;
+  /** Layer hex color for satellite */
+  layer_color_satellite?: string;
+  /** Layer hex color for streets */
+  layer_color_streets?: string;
+  /** Circle radius if point layer */
+  circle_radius?: number;
   /** Layer visible on map */
   visible: boolean;
   /** Button icon if small button */

--- a/frontend/naturewatch/src/interfaces/MapLayerInterface.ts
+++ b/frontend/naturewatch/src/interfaces/MapLayerInterface.ts
@@ -1,4 +1,5 @@
 import type { MapLayerType, MapLayerButtonType } from '../types/MapLayerType';
+import type MapLayerPaint from '../interfaces/MapLayerPaintInterface';
 
 /** Map Layer Interface */
 export default interface MapLayer {
@@ -8,8 +9,12 @@ export default interface MapLayer {
   button_type: MapLayerButtonType;
   /** Layer source url */
   url: string;
-  /** Layer type */
+  /** Layer type: one of raster, line, point */
   type: MapLayerType;
+  /** Source layer from Mapbox */
+  sourceLayer?: string;
+  /** Layer source url */
+  paint?: MapLayerPaint;
   /** Layer visible on map */
   visible: boolean;
   /** Button icon if small button */

--- a/frontend/naturewatch/src/interfaces/MapLayerPaintInterface.ts
+++ b/frontend/naturewatch/src/interfaces/MapLayerPaintInterface.ts
@@ -1,0 +1,4 @@
+export default interface Paint {
+  'circle-color': string;
+  'circle-radius': number;
+}

--- a/frontend/naturewatch/src/interfaces/MapLayerPaintInterface.ts
+++ b/frontend/naturewatch/src/interfaces/MapLayerPaintInterface.ts
@@ -1,4 +1,0 @@
-export default interface Paint {
-  'circle-color': string;
-  'circle-radius': number;
-}

--- a/frontend/naturewatch/src/store/MapLayerStore.ts
+++ b/frontend/naturewatch/src/store/MapLayerStore.ts
@@ -96,10 +96,15 @@ const useMapLayerStore = defineStore('mapLayer', () => {
       title: 'Dams',
       button_type: 'small',
       url: 'mapbox://nature-watch.dam-test-tiles',
-      type: 'vector',
+      type: 'circle',
+      sourceLayer: 'dams',
+      paint: {
+        'circle-color': '#345459',
+        'circle-radius': 3,
+      },
       visible: false,
-      icon: 'mdi-barley',
-      button_color: 'red-lighten-3',
+      icon: 'mdi-bridge',
+      button_color: '#b7e6f1',
       active: true,
     },
   ]);

--- a/frontend/naturewatch/src/store/MapLayerStore.ts
+++ b/frontend/naturewatch/src/store/MapLayerStore.ts
@@ -98,10 +98,9 @@ const useMapLayerStore = defineStore('mapLayer', () => {
       url: 'mapbox://nature-watch.dam-test-tiles',
       type: 'circle',
       sourceLayer: 'dams',
-      paint: {
-        'circle-color': '#345459',
-        'circle-radius': 3,
-      },
+      layer_color_satellite: '#b7e6f1',
+      layer_color_streets: '#5b7378',
+      circle_radius: 4,
       visible: false,
       icon: 'mdi-bridge',
       button_color: '#b7e6f1',

--- a/frontend/naturewatch/src/store/MapLayerStore.ts
+++ b/frontend/naturewatch/src/store/MapLayerStore.ts
@@ -92,6 +92,16 @@ const useMapLayerStore = defineStore('mapLayer', () => {
       button_color: 'brown-lighten-1',
       active: true,
     },
+    {
+      title: 'Dams',
+      button_type: 'small',
+      url: 'mapbox://nature-watch.dam-test-tiles',
+      type: 'vector',
+      visible: false,
+      icon: 'mdi-barley',
+      button_color: 'red-lighten-3',
+      active: true,
+    },
   ]);
 
   // Getters

--- a/frontend/naturewatch/src/types/MapLayerType.ts
+++ b/frontend/naturewatch/src/types/MapLayerType.ts
@@ -1,2 +1,2 @@
-export type MapLayerType = 'raster' | 'vector';
+export type MapLayerType = 'raster' | 'line' | 'circle';
 export type MapLayerButtonType = 'big' | 'small';


### PR DESCRIPTION
## Description
I created an example of adding vector tiles to the map by adding a "dams" layer. For now I just created Mapbox Vector Tiles, but in the future we may consider something like pmtiles from [Protomaps](https://protomaps.com/) if Mapbox' hosting becomes to expensive.

- A vector layer can now be added to the map and is placed above any line layers, but below any label (symbol) layers
- I extended the MapLayerInterface to include some optional properties if the map layer is a vector
- We can specify a darker and a lighter color in the MapLayerStore for vector layers to use depending on whether the satellite or streets basemap style is active

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions/changes to the documentation


## User Experience:

![vector](https://github.com/marynvdl/naturewatch-app/assets/46701604/493e663a-d987-470e-bf83-ca3ffe18ecd8)

