### PR TITLE
Change built tile layer url

### DIFF
--- a/frontend/naturewatch/src/store/MapLayerStore.ts
+++ b/frontend/naturewatch/src/store/MapLayerStore.ts
@@ -24,7 +24,7 @@ const useMapLayerStore = defineStore('mapLayer', () => {
     {
       title: 'Built',
       button_type: 'small',
-      url: 'https://storage.googleapis.com/nature-watch-bucket/tiles/built/2022/{z}/{x}/{y}.png',
+      url: 'https://storage.googleapis.com/nature-watch-tiles/built/2022/{z}/{x}/{y}.png',
       type: 'raster',
       visible: false,
       icon: 'mdi-office-building',


### PR DESCRIPTION
## Description

Update the Built tile layer's url to a different bucket that contains tiles of zoom level 0-12 with max resampling.

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions/changes to the documentation


## User Experience:

![built](https://github.com/marynvdl/naturewatch-app/assets/46701604/510306d6-64cf-40f3-9d62-01f79a1d089a)
