### PR TITLE
Ensure posthog token is available at build

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run integration test suite in docker
         run: docker-compose exec -T naturewatch-test pytest -m integration app/tests -vv
       - name: Try a full docker compile to flag any JS issues too
-        run: docker build -t naturewatch .
+        run: docker build --build-arg VITE_APP_POSTHOG_TOKEN=${{ secrets.POSTHOG_TOKEN }} -t naturewatch .
 
   deploy_test_app:
       name: Deploy Test App

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN npm install
 # Copy Frontend source files
 COPY ./frontend/naturewatch/ ./
 
+# Make the build argument available as an environment variable
+ENV VITE_APP_POSTHOG_TOKEN $VITE_APP_POSTHOG_TOKEN
+
 # Compile and Minify for Production
 RUN npm run build
 


### PR DESCRIPTION
## Description

As the build process for the Vue application is happening in GitHub Actions, we need to specify the Posthog environmental variable during the Docker build.

In fly.yml:
```
run: docker build --build-arg VITE_APP_POSTHOG_TOKEN=${{ secrets.POSTHOG_TOKEN }} -t naturewatch .
```

In Dockerfile:
```
# Make the build argument available as an environment variable
ENV VITE_APP_POSTHOG_TOKEN $VITE_APP_POSTHOG_TOKEN
```

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions/changes to the documentation


## User Experience:
Posthog working on test and production site