### PR TITLE
Add github concurrency to cancel in progress runs when new runs start

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -28,6 +28,9 @@ jobs:
       name: Deploy Test App
       needs: test_suite
       runs-on: ubuntu-latest
+      concurrency: 
+        group: deploy-test-app-${{ github.ref }}
+        cancel-in-progress: true
       if: github.ref == 'refs/heads/develop'
       steps:
         - name: Check out source code
@@ -43,6 +46,9 @@ jobs:
       name: Deploy Demo App
       needs: test_suite
       runs-on: ubuntu-latest
+      concurrency: 
+        group: deploy-demo-app-${{ github.ref }}
+        cancel-in-progress: true
       if: github.ref == 'refs/heads/main'
       steps:
         - name: Check out source code


### PR DESCRIPTION
## Description

Add GitHub concurrency groups to both the test and demo app to cancel in progress runs whenever a new run is started.

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions/changes to the documentation


## User Experience:

New GitHub Action runs will cancel in progress runs of the same group.
