### PR TITLE
Update query string for treeloss tiles

### DIFF
--- a/frontend/naturewatch/src/store/MapLayerStore.ts
+++ b/frontend/naturewatch/src/store/MapLayerStore.ts
@@ -38,7 +38,7 @@ const useMapLayerStore = defineStore('mapLayer', () => {
     {
       title: 'Treeloss',
       button_type: 'small',
-      url: 'https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png',
+      url: 'https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.12/dynamic/{z}/{x}/{y}.png',
       years_available: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023],
       type: 'raster',
       visible: false,
@@ -46,7 +46,7 @@ const useMapLayerStore = defineStore('mapLayer', () => {
       icon: 'mdi-tree',
       button_color: '#D487A4',
       active: true,
-      query_string: `?start_year=2000&end_year={year}`,
+      query_string: `?&start_year=2001&end_year={year}&render_type=true_color`,
     },
     {
       title: 'Fire',


### PR DESCRIPTION
## Description

Treeloss stopped working on Nature Watch. I fixed this by updating the query string.

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## User Experience:

Treeloss is working again.
