### PR TITLE
Update timeline and treeloss to include 2024

### DIFF
--- a/frontend/naturewatch/src/components/TimelineComponent.vue
+++ b/frontend/naturewatch/src/components/TimelineComponent.vue
@@ -37,7 +37,7 @@ watch(selectedYear, (newYear, oldYear) => {
           show-ticks="always"
           tick-size="6"
           :min="2016"
-          :max="2023"
+          :max="2024"
           :step="1"
           thumb-label="always"
         />

--- a/frontend/naturewatch/src/store/MapLayerStore.ts
+++ b/frontend/naturewatch/src/store/MapLayerStore.ts
@@ -39,7 +39,7 @@ const useMapLayerStore = defineStore('mapLayer', () => {
       title: 'Treeloss',
       button_type: 'small',
       url: 'https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.12/dynamic/{z}/{x}/{y}.png',
-      years_available: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023],
+      years_available: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024],
       type: 'raster',
       visible: false,
       opacity: 100,

--- a/frontend/naturewatch/src/store/TimelineStore.ts
+++ b/frontend/naturewatch/src/store/TimelineStore.ts
@@ -5,7 +5,7 @@ const useTimelineStore = defineStore('timeline', () => {
   // State
   /** Loading overlay */
   const visible: Ref<boolean> = ref(false);
-  const activeYear: Ref<number> = ref(2023);
+  const activeYear: Ref<number> = ref(2024);
   const lastActiveYear: Ref<number> = ref(2016);
 
   // Getters


### PR DESCRIPTION
## Description

Adds an option for 2024 to the timeline and shows treeloss for 2024.

## Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've checked if Unit/Integration tests should be added/modified
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions/changes to the documentation


## User Experience:

The user can view treeloss for 2024.